### PR TITLE
S2-LP Read RX FIFO Fuction

### DIFF
--- a/cdh-tsat6-stm32project-nucleo/Drivers/Hardware_Peripherals/Inc/SP-L2_driver.h
+++ b/cdh-tsat6-stm32project-nucleo/Drivers/Hardware_Peripherals/Inc/SP-L2_driver.h
@@ -35,7 +35,7 @@ typedef enum
  *
  * *Note* The Radio will use SPI 2 on the mcu.
  */
-SPL2_StatusTypeDef SPL2_Spi_Send_Message(uint8_t * pData, size_t numToSend);
+SPL2_StatusTypeDef SPL2_SPI_Send_Message(uint8_t * pData, size_t numToSend);
 
 
 /**
@@ -43,7 +43,7 @@ SPL2_StatusTypeDef SPL2_Spi_Send_Message(uint8_t * pData, size_t numToSend);
  *
  *
  */
-SPL2_StatusTypeDef SPL2_Spi_Receive_Message(uint8_t * pData, size_t numToReceive);
+SPL2_StatusTypeDef SPL2_SPI_Receive_Message(uint8_t * pData, size_t numToReceive);
 
 
 /**
@@ -79,12 +79,21 @@ SPL2_StatusTypeDef S2LP_Spi_Write_TX_Fifo(uint8_t address, uint8_t n_regs, uint8
 
 
 /**
- * @brief Reads the S2-LP RX FIFO.
- *
- *
+ * @brief Reads given amount of bytes from RX FIFO.
+ * 
+ * @param n_bytes number of bytes to read
+ * @param buffer buffer for received bytes
+ * @return SPL2_StatusTypeDef 
  */
-SPL2_StatusTypeDef S2LP_Spi_Read_RX_Fifo(uint8_t address, uint8_t n_regs, uint8_t* buffer);
+SPL2_StatusTypeDef S2LP_Read_RX_FIFO(uint8_t n_bytes, uint8_t* buffer);
 
+/**
+ * @brief Fetches a count of RX values waiting in the FIFO
+ * 
+ * @param lengthBuffer return buffer for length
+ * @return SPL2_StatusTypeDef 
+ */
+SPL2_StatusTypeDef SPL2_Check_RX_FIFO_Status(uint8_t * lengthBuffer);
 
 /**
  * @brief Reads the S2-LP RX FIFO.

--- a/cdh-tsat6-stm32project-nucleo/Drivers/Hardware_Peripherals/Src/SP-L2_driver.c
+++ b/cdh-tsat6-stm32project-nucleo/Drivers/Hardware_Peripherals/Src/SP-L2_driver.c
@@ -58,15 +58,19 @@ SPL2_StatusTypeDef S2LP_Read_RX_FIFO(uint8_t n_bytes, uint8_t* buffer){
 		numToFetch = avaliableBytes;
 	}
 
-	// pull down cs
+	// Pull down to select
+	status = S2LP_nCS(S2LP_CS_SELECT);
+	if(status != SPL2_HAL_OK) goto error;
 
-	SPL2_SPI_Send_Message(0xFF80, 2);
+	status = SPL2_SPI_Send_Message(0xFF80, 2);
 	if(status != SPL2_HAL_OK) goto error;
 
 	status = SPL2_SPI_Receive_Message(buffer, numToFetch);
 	if(status != SPL2_HAL_OK) goto error;
 
-	// pull up cs
+	// Pull up to release
+	status = S2LP_nCS(S2LP_CS_RELEASE);
+	if(status != SPL2_HAL_OK) goto error;
 
 	error:
 		return status;

--- a/cdh-tsat6-stm32project-nucleo/Drivers/Hardware_Peripherals/Src/SP-L2_driver.c
+++ b/cdh-tsat6-stm32project-nucleo/Drivers/Hardware_Peripherals/Src/SP-L2_driver.c
@@ -11,12 +11,12 @@
 
 #include "SP-L2_driver.h"
 
-SPL2_StatusTypeDef SPL2_Spi_Send_Message(uint8_t * pData, size_t numToSend){
+SPL2_StatusTypeDef SPL2_SPI_Send_Message(uint8_t * pData, size_t numToSend){
 
 	return HAL_SPI_Transmit(&hspi2, pData, numToSend, HAL_MAX_DELAY);
 }
 
-SPL2_StatusTypeDef SPL2_Spi_Receive_Message(uint8_t * pData, size_t numToReceive){
+SPL2_StatusTypeDef SPL2_SPI_Receive_Message(uint8_t * pData, size_t numToReceive){
 
 	return HAL_SPI_Receive_DMA(&hspi2, pData, numToReceive);
 }
@@ -24,4 +24,50 @@ SPL2_StatusTypeDef SPL2_Spi_Receive_Message(uint8_t * pData, size_t numToReceive
 SPL2_StatusTypeDef SPL2_SPI_Transmit_Receive_Message(uint8_t *pTxData, uint8_t *pRxData, size_t numTransmitReceive){
 
 	return HAL_SPI_TransmitReceive(&hspi2, pTxData, pRxData, numTransmitReceive);
+}
+
+SPL2_StatusTypeDef SPL2_Check_RX_FIFO_Status(uint8_t * lengthBuffer){
+
+	SPL2_StatusTypeDef status = SPL2_HAL_OK;
+
+	// Should we pull down here??? Probably not?
+	status = S2LP_Spi_Read_Registers(0x90, 2, &lengthBuffer);
+	if(status != SPL2_HAL_OK) goto error;
+
+
+	error:
+		return status;
+}
+
+SPL2_StatusTypeDef S2LP_Read_RX_FIFO(uint8_t n_bytes, uint8_t* buffer){
+
+	SPL2_StatusTypeDef status = SPL2_HAL_OK;
+	uint8_t avaliableBytes = 0;
+	uint8_t numToFetch = 0;
+
+	// First we need to check how many messages are in the FIFO
+	status = SPL2_CHECK_RX_FIFO_STATUS(&avaliableBytes); // Change naming standard away from SPI if not directly an SPI command?
+	if(status != SPL2_HAL_OK) goto error;
+
+	// If there are enough bytes ready for requested amount count
+	// Else get as many as avaliable
+	if(avaliableBytes > n_bytes){
+		numToFetch = n_bytes;
+	}
+	else{
+		numToFetch = avaliableBytes;
+	}
+
+	// pull down cs
+
+	SPL2_SPI_Send_Message(0xFF80, 2);
+	if(status != SPL2_HAL_OK) goto error;
+
+	status = SPL2_SPI_Receive_Message(buffer, numToFetch);
+	if(status != SPL2_HAL_OK) goto error;
+
+	// pull up cs
+
+	error:
+		return status;
 }


### PR DESCRIPTION
I have added the function of reading the RX FIFO of the S2-LP. 

Two functions have been added. 

The first **SPL2_Check_RX_FIFO_Status** will check if any messages are waiting in the RX FIFO.

The second **S2LP_Read_RX_FIFO** will fetch the given amount of messages from the RX FIFO. It does this by first checking if there are any messages in the FIFO using SPL2_Check_RX_FIFO_Status, if there are enough bytes available it will fetch as many as requested if there are not it will only fetch as many as are available.

Graham D
graham.driver@umsats.ca