### PR TITLE
S2 lp transmit fifo

### DIFF
--- a/cdh-tsat6-stm32project-nucleo/Drivers/Hardware_Peripherals/Inc/SP-L2_driver.h
+++ b/cdh-tsat6-stm32project-nucleo/Drivers/Hardware_Peripherals/Inc/SP-L2_driver.h
@@ -24,10 +24,11 @@
 
 typedef enum
 {
-	SPL2_HAL_OK                     = HAL_OK,      //0x00
-	SPL2_HAL_ERROR                  = HAL_ERROR,   //0x01
-	SPL2_HAL_BUSY                   = HAL_BUSY,    //0x02
-	SPL2_HAL_TIMEOUT                = HAL_TIMEOUT, //0x03
+	SPL2_HAL_OK                     = HAL_OK,      	//0x00
+	SPL2_HAL_ERROR                  = HAL_ERROR,   	//0x01
+	SPL2_HAL_BUSY                   = HAL_BUSY,    	//0x02
+	SPL2_HAL_TIMEOUT                = HAL_TIMEOUT, 	//0x03
+	SPL2_TX_FIFO_FULL,
 } SPL2_StatusTypeDef;
 
 //###############################################################################################
@@ -74,13 +75,23 @@ SPL2_StatusTypeDef S2LP_Spi_Write_Registers(uint8_t address, uint8_t n_regs, uin
  */
 SPL2_StatusTypeDef S2LP_Spi_Read_Registers(uint8_t address, uint8_t n_regs, uint8_t* buffer);
 
+/**
+ * @brief This function will read the register that contains a counter for the amount of bytes in TX FIFO.
+ * 
+ * @param lengthBuffer The amount of bytes in the FIFO
+ * @return SPL2_StatusTypeDef 
+ */
+SPL2_StatusTypeDef SPL2_Check_TX_FIFO_Status(uint8_t * lengthBuffer);
 
 /**
- * @brief Writes to the S2-LP TX FIFO.
- *
- *
+ * @brief This function will send data to the S2LP driver if there is space.
+ * If there is no space available in the FIFO it will return SPL2_TX_FIFO_FULL.
+ * 
+ * @param size The size of the packet that is being sent
+ * @param buffer A buffer containing data to be sent
+ * @return SPL2_StatusTypeDef 
  */
-SPL2_StatusTypeDef S2LP_Spi_Write_TX_Fifo(uint8_t address, uint8_t n_regs, uint8_t* buffer);
+SPL2_StatusTypeDef S2LP_Write_TX_Fifo(uint8_t size, uint8_t* buffer);
 
 
 /**
@@ -106,8 +117,10 @@ SPL2_StatusTypeDef S2LP_Spi_Send_Command(uint8_t address, uint8_t n_regs, uint8_
 SPL2_StatusTypeDef S2LP_Reset();
 
 /**
- * @brief Sets the chip select state using S2LP_nCS_SELECT and S2LP_nCS_RELEASE.
+ * @brief Will either pull down chip select when passed S2LP_CS_SELECT,
+ * or released high with S2LP_CS_RELEASE.
  * 
+ * @param sel Use S2LP_CS_SELECT and S2LP_CS_RELEASE to select the device or release it
  * @return SPL2_StatusTypeDef 
  */
 SPL2_StatusTypeDef S2LP_nCS(uint8_t sel);

--- a/cdh-tsat6-stm32project-nucleo/Drivers/Hardware_Peripherals/Inc/SP-L2_driver.h
+++ b/cdh-tsat6-stm32project-nucleo/Drivers/Hardware_Peripherals/Inc/SP-L2_driver.h
@@ -16,6 +16,11 @@
 //###############################################################################################
 #include "stm32l4xx_hal.h"
 #include "main.h"
+#include <stdio.h>
+#include <string.h>
+
+#define S2LP_CS_SELECT 0
+#define S2LP_CS_RELEASE 1
 
 typedef enum
 {
@@ -91,7 +96,7 @@ SPL2_StatusTypeDef S2LP_Spi_Read_RX_Fifo(uint8_t address, uint8_t n_regs, uint8_
  *
  *
  */
-SPL2_StatusTypeDef S2LP_Spi_Send_Command(uint8_t commandByte);
+SPL2_StatusTypeDef S2LP_Spi_Send_Command(uint8_t address, uint8_t n_regs, uint8_t* buffer);
 
 /**
  * @brief Shuts down SP-L2.
@@ -100,6 +105,11 @@ SPL2_StatusTypeDef S2LP_Spi_Send_Command(uint8_t commandByte);
  */
 SPL2_StatusTypeDef S2LP_Reset();
 
-
+/**
+ * @brief Sets the chip select state using S2LP_nCS_SELECT and S2LP_nCS_RELEASE.
+ * 
+ * @return SPL2_StatusTypeDef 
+ */
+SPL2_StatusTypeDef S2LP_nCS(uint8_t sel);
 
 #endif /* HARDWARE_PERIPHERALS_INC_SP_L2_DRIVER_H_ */

--- a/cdh-tsat6-stm32project-nucleo/Drivers/Hardware_Peripherals/Inc/SP-L2_driver.h
+++ b/cdh-tsat6-stm32project-nucleo/Drivers/Hardware_Peripherals/Inc/SP-L2_driver.h
@@ -90,6 +90,8 @@ SPL2_StatusTypeDef SPL2_Check_TX_FIFO_Status(uint8_t * lengthBuffer);
  * @param size The size of the packet that is being sent
  * @param buffer A buffer containing data to be sent
  * @return SPL2_StatusTypeDef 
+ * 
+ * @note The TX FIFO can only store 128 bytes 
  */
 SPL2_StatusTypeDef S2LP_Write_TX_Fifo(uint8_t size, uint8_t* buffer);
 

--- a/cdh-tsat6-stm32project-nucleo/Drivers/Hardware_Peripherals/Src/SP-L2_driver.c
+++ b/cdh-tsat6-stm32project-nucleo/Drivers/Hardware_Peripherals/Src/SP-L2_driver.c
@@ -11,17 +11,82 @@
 
 #include "SP-L2_driver.h"
 
+
 SPL2_StatusTypeDef SPL2_Spi_Send_Message(uint8_t * pData, size_t numToSend){
 
 	return HAL_SPI_Transmit(&hspi2, pData, numToSend, HAL_MAX_DELAY);
 }
+
 
 SPL2_StatusTypeDef SPL2_Spi_Receive_Message(uint8_t * pData, size_t numToReceive){
 
 	return HAL_SPI_Receive_DMA(&hspi2, pData, numToReceive);
 }
 
+
 SPL2_StatusTypeDef SPL2_SPI_Transmit_Receive_Message(uint8_t *pTxData, uint8_t *pRxData, size_t numTransmitReceive){
 
 	return HAL_SPI_TransmitReceive(&hspi2, pTxData, pRxData, numTransmitReceive);
+}
+
+SPL2_StatusTypeDef SPL2_Check_TX_FIFO_Status(uint8_t * lengthBuffer){
+	SPL2_StatusTypeDef status = SPL2_HAL_OK;
+
+	// Should we pull down here??? Probably not?
+	// We should probably create a typedef of all/most used registers
+	status = S2LP_Spi_Read_Registers(0x8D, 1, &lengthBuffer);
+	if(status != SPL2_HAL_OK) goto error;
+
+
+	error:
+		return status;
+}
+
+
+SPL2_StatusTypeDef S2LP_Write_TX_Fifo(uint8_t size, uint8_t* buffer){
+	// Will not check if FIFO is full yet but feature should be implemented in final release
+
+	SPL2_StatusTypeDef status;
+	uint8_t storedBytes = 0;
+
+	// First we need to check how many messages are in the FIFO
+	status = SPL2_Check_TX_FIFO_Status(&storedBytes); // Change naming standard away from SPI if not directly an SPI command?
+	if(status != SPL2_HAL_OK) goto error;
+
+	// If there is room in FIFO send bytes (FIFO can store 128 bytes)
+	// Else return FIFO full status
+	if(storedBytes + size >= 128){
+
+		// Pull down CS
+		S2LP_nCS(S2LP_CS_SELECT);
+
+		// Send one byte of zeros to indicate we are writing an address 
+		status = SPL2_Spi_Send_Message(0xFF00, 1);
+		if(status != SPL2_HAL_OK) goto error;
+
+		// Send our data to FIFO
+		status = SPL2_Spi_Send_Message(data, size);
+		if(status != SPL2_HAL_OK) goto error;
+
+		// Pull up CS to stop communication
+		S2LP_nCS(S2LP_CS_SELECT);
+	}
+	else{
+		return SPL2_TX_FIFO_FULL; // FIFO is full cannot send data
+	}
+
+	error:
+		return status;
+}
+
+
+SPL2_StatusTypeDef S2LP_nCS(uint8_t sel){
+
+	if(sel){
+		HAL_GPIO_WritePin(UHF_nCS_GPIO_Port, UHF_nCS_Pin, GPIO_PIN_SET);
+	}
+	else{
+		HAL_GPIO_WritePin(UHF_nCS_GPIO_Port, UHF_nCS_Pin, GPIO_PIN_RESET);
+	}
+
 }


### PR DESCRIPTION
I have added the function of writing to the TX FIFO of the S2-LP and the chip select function.

Three functions have been added:

**S2LP_Write_TX_Fifo**: This function is used to write bytes to the TX FIFO of the SPL2. It will check if there is room in the FIFO and will either write the bytes if there is room otherwise it will return an error indicating there is no space for the data. (Note: TX FIFO has a max 128 bytes)

**SPL2_Check_TX_FIFO_Status**: This function is used as a helper it fetches how many bytes are currently queued in the SPL2 TX FIFO.

**S2LP_nCS**: The chip select function for the SPL2.

Still need to resolve merge conflicts

Graham D
[graham.driver@umsats.ca](mailto:graham.driver@umsats.ca)